### PR TITLE
Update content-single.php

### DIFF
--- a/template-parts/content-single.php
+++ b/template-parts/content-single.php
@@ -23,7 +23,11 @@
 		<?php endif; ?>
 		
 		<?php gruene_the_featured_image(); ?>
-
+		<?php if ( 'post' == get_post_type() && ! is_sticky() && 'short' == get_theme_mod( 'title_length', 'normal' )) : ?>
+       		<div class="entry-meta">
+				<?php gruene_posted_on( true); ?>
+       		</div><!-- .entry-meta -->
+		<?php endif; ?>
     </header><!-- .entry-header -->
 
     <div class="entry-content">


### PR DESCRIPTION
Show Post-Date on Single Post page before the content too - even if the title is "short".
Reason: in a Blog Post, the date can be of the essence. if it is only show at the end for entries with a short title, this ist not ideal and the date tends to be overlooked.

TBD before pull: evaluate the best exact position of the Date, also in context with the styling