### PR TITLE
Added Header to add Twitter "Do Not Track" Tag

### DIFF
--- a/header.php
+++ b/header.php
@@ -11,6 +11,7 @@
 <head>
     <meta charset="<?php bloginfo( 'charset' ); ?>">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="twitter:dnt" content="on">
     <link rel="profile" href="http://gmpg.org/xfn/11">
     <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>">
     <meta name="theme-color" content="#84b414">


### PR DESCRIPTION
According to [https://developer.twitter.com/en/docs/twitter-for-websites/privacy](https://developer.twitter.com/en/docs/twitter-for-websites/privacy) this meta entry allows a website owner to opt out of having information from your website i.e. from embedded tweets or twitter timelines used for personalization.